### PR TITLE
feat: implement ScrollToTop to reset scroll position on route change

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { UserProvider } from "./components/context/UserContext.jsx";
 import { VenueProvider } from "./components/context/VenueContext.jsx";
+import ScrollToTop from "./utils/ScrollToTop.jsx";
 import "./index.css";
 import App from "./App.jsx";
 
@@ -11,6 +12,7 @@ createRoot(document.getElementById("root")).render(
     <BrowserRouter>
       <UserProvider>
         <VenueProvider>
+          <ScrollToTop />
           <App />
         </VenueProvider>
       </UserProvider>

--- a/src/utils/ScrollToTop.jsx
+++ b/src/utils/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Added a ScrollToTop component to reset the scroll position to the top when navigating between routes.

Closes #153 